### PR TITLE
[bug-fix]: incorrect URL mentioned in readme.md 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 
-This repository holds the source code of the website [https://qcm.github.io/synonyms-in-quran/](qcm.github.io/synonyms-in-quran/) and MD files.
+This repository holds the source code of the website [https://nqcm.github.io/synonyms-in-quran/](nqcm.github.io/synonyms-in-quran/) and MD files.
 
 # Synonyms in Quran
 


### PR DESCRIPTION
## Bug
The website url mentioned in the readme.md does not lead to the intended website.

Following are some screenshots for reference:

![image](https://github.com/nqcm/synonyms-in-quran/assets/74227188/07d8a1eb-3dab-4093-b302-f634a71bf1c5)

![image](https://github.com/nqcm/synonyms-in-quran/assets/74227188/ce208f89-e30a-4757-b365-4c1a667ffc0d)

## Bug Fix
I've corrected the url to "https://nqcm.github.io/synonyms-in-quran/"

#### P.S.
For some reason, I wasn't able to create an issue on your repository. Hope this PR will be useful, please consider merging it. Thanks.